### PR TITLE
Corrected flaw in build scripts

### DIFF
--- a/https-server/build.sh
+++ b/https-server/build.sh
@@ -21,11 +21,11 @@
 # Optionally push to external image repo
 
 print_usage() {
-    echo "Usage: build.sh no-push|<docker-hub-repo-name> [<image-tag>]"
+    echo "Usage: build.sh no-push|<docker-hub-repo-name> [--tag <image-tag>]"
     exit 1
 }
 
-if [ $# -lt 1 ] || [ $# -gt 2 ]; then
+if [ $# -ne 1 ] && [ $# -ne 3 ]; then
     print_usage
 fi
 

--- a/pm-file-converter/README.md
+++ b/pm-file-converter/README.md
@@ -14,7 +14,7 @@ Build for docker or local kubernetes\
 `./build.sh no-push`
 
 Build for remote kubernetes - an externally accessible image repo (e.g. docker hub) is needed  \
-`./build.sh <external-image-repo>`
+`./build.sh <external-image-repo> [--tag <image-tag>]`
 
 ### Function
 

--- a/pm-file-converter/build.sh
+++ b/pm-file-converter/build.sh
@@ -25,7 +25,7 @@ print_usage() {
     exit 1
 }
 
-if [ $# -lt 1 ] || [ $# -gt 2 ]; then
+if [ $# -ne 1 ] && [ $# -ne 3 ]; then
     print_usage
 fi
 

--- a/pm-rapp/README.md
+++ b/pm-rapp/README.md
@@ -8,7 +8,7 @@ Build for docker or local kubernetes\
 `./build.sh no-push [<image-tag>]`
 
 Build for remote kubernetes - an externally accessible image repo (e.g. docker hub) is needed  \
-`./build.sh <external-image-repo> [<image-tag>]`
+`./build.sh <external-image-repo> [--tag <image-tag>]`
 
 ## Function
 

--- a/pm-rapp/build.sh
+++ b/pm-rapp/build.sh
@@ -21,11 +21,11 @@
 # Optionally push to external image repo
 
 print_usage() {
-    echo "Usage: build.sh no-push|<docker-hub-repo-name> [<image-tag>]"
+    echo "Usage: build.sh no-push|<docker-hub-repo-name> [--tag <image-tag>]"
     exit 1
 }
 
-if [ $# -ne 1 ] && [ $# -ne 2 ]; then
+if [ $# -ne 1 ] && [ $# -ne 3 ]; then
     print_usage
 fi
 


### PR DESCRIPTION
When using build.sh to build and push to image registry correct number of parameters should be either 1 (no-push/registry-name) or 3 (registry-name --tag tag-name)